### PR TITLE
Fix typo (from upstream).

### DIFF
--- a/neosnippets/twig.snip
+++ b/neosnippets/twig.snip
@@ -69,7 +69,7 @@ options     head
 snippet     else
 abbr        {% else %} ...
 options     head
-	{$ else %}
+	{% else %}
 		${0:TARGET}
 
 snippet     import


### PR DESCRIPTION
I noticed [this](/Shougo/neosnippet-snippets/commit/8a939576e20edf518bee101c69be5d067cd00e03) when I made my pull request at neosnippet-snippets. (This makes the two files identical.)